### PR TITLE
feat(content): add basic usage

### DIFF
--- a/docs/developing/basic-usage.md
+++ b/docs/developing/basic-usage.md
@@ -2,6 +2,97 @@
 sidebar_position: 1
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+import { logoIonic } from 'ionicons/icons';
+import { defineCustomElement } from 'ionicons/components/ion-icon.js';
+defineCustomElement();
+
 # Basic Usage
 
-TODO Basic Usage
+<ion-icon icon={logoIonic}></ion-icon>
+
+<Tabs>
+<TabItem value="angular" label="Angular">
+
+```html
+<ion-icon name="logo-ionic"></ion-icon>
+```
+</TabItem>
+
+<TabItem value="javascript" label="JavaScript">
+
+```html
+<ion-icon name="logo-ionic"></ion-icon>
+```
+</TabItem>
+
+<TabItem value="react" label="React">
+
+```tsx title="With Ionic Framework"
+import { IonIcon } from '@ionic/react';
+import { logoIonic } from 'ionicons/icons';
+
+const Example = () => {
+  return <IonIcon icon={logoIonic} />
+}
+
+export default Example;
+```
+
+```tsx title="Without Ionic Framework"
+import { defineCustomElement as defineIonIcon } from 'ionicons';
+import { logoIonic } from 'ionicons/icons';
+
+defineIonIcon();
+
+const Example = () => {
+  return <ion-icon icon={logoIonic}></ion-icon>
+}
+
+export default Example;
+```
+</TabItem>
+
+<TabItem value="vue" label="Vue">
+
+```html title="With Ionic Framework"
+<template>
+  <ion-icon :icon="logoIonic"></ion-icon>
+</template>
+
+<script>
+  import { defineComponent } from 'vue';
+  import { IonIcon } from 'ionicons';
+  import { logoIonic } from 'ionicons/icons';
+
+  export default defineComponent({
+    components: { IonIcon },
+    setup() {
+      return { logoIonic }
+    }
+  });
+</script>
+```
+
+```html title="Without Ionic Framework"
+<template>
+  <ion-icon :icon="logoIonic"></ion-icon>
+</template>
+
+<script>
+  import { defineComponent } from 'vue';
+  import { defineCustomElement as defineIonIcon } from 'ionicons';
+  import { logoIonic } from 'ionicons/icons';
+
+  export default defineComponent({
+    setup() {
+      defineIonIcon();
+      return { logoIonic }
+    }
+  });
+</script>
+```
+</TabItem>
+</Tabs>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@docusaurus/preset-classic": "2.1.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
+        "ionicons": "^6.0.3",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -2835,6 +2836,18 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@stencil/core": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.1.tgz",
+      "integrity": "sha512-s/UJp9qxExL3DyQPT70kiuWeb3AdjbUZM+5lEIXn30I2DLcLYPOPXfsoWJODieQywq+3vPiLZeIdkoqjf6jcSw==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -6971,6 +6984,14 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ionicons": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.3.tgz",
+      "integrity": "sha512-kVOWER991EMqLiVShrCSWKMHkgHZP7XfVdyN6YPMuoO33W7pc5CPNVNfR8OMe/I8rYEbaunyBs6dXNYpR6gGZw==",
+      "dependencies": {
+        "@stencil/core": "~2.16.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -14373,6 +14394,11 @@
         "webpack-sources": "^3.2.2"
       }
     },
+    "@stencil/core": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.1.tgz",
+      "integrity": "sha512-s/UJp9qxExL3DyQPT70kiuWeb3AdjbUZM+5lEIXn30I2DLcLYPOPXfsoWJODieQywq+3vPiLZeIdkoqjf6jcSw=="
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.3.1.tgz",
@@ -17405,6 +17431,14 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "ionicons": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.3.tgz",
+      "integrity": "sha512-kVOWER991EMqLiVShrCSWKMHkgHZP7XfVdyN6YPMuoO33W7pc5CPNVNfR8OMe/I8rYEbaunyBs6dXNYpR6gGZw==",
+      "requires": {
+        "@stencil/core": "~2.16.0"
       }
     },
     "ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@docusaurus/preset-classic": "2.1.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "ionicons": "^6.0.3",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
Adds usage for JS, Angular, React, and Vue for how to import and add an ion-icon. This example has separate code blocks for Ionic Framework and non-Ionic Framework apps since the import path/setup steps are different.