### PR TITLE
docs(developing): add custom icon docs

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -17,6 +17,22 @@ import BasicUsage from '@site/static/usage/basic-usage.md';
 
 ## Custom Icons
 
+### With a URL
+
+To use a custom SVG from a url, pass the URL to the `icon` property. Make sure that the file accessible from the webpage that is making the request. For security reasons, Ionicons does not allow scripts or events within the custom SVG element.
+
+import CustomURL from '@site/static/usage/custom-icons/url.md';
+
+<CustomURL />
+
+### With SVG Data
+
+Developers can also pass the raw SVG data to the `icon` property. For security reasons, Ionicons does not allow scripts or events within the custom SVG element.
+
+import CustomData from '@site/static/usage/custom-icons/data.md';
+
+<CustomData />
+
 ## Variants
 
 Each app icon in Ionicons has a `filled`, `outline`, and `sharp` variant. These different variants are provided to make your app feel native to a variety of platforms. The filled variant uses the default name without a suffix. Note: Logo icons do not have outline or sharp variants.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -19,7 +19,7 @@ import BasicUsage from '@site/static/usage/basic-usage.md';
 
 ### With a URL
 
-To use a custom SVG from a url, pass the URL to the `icon` property. Make sure that the file accessible from the webpage that is making the request. For security reasons, Ionicons does not allow scripts or events within the custom SVG element.
+To load a custom SVG from a url, pass the URL to the `icon` property. Make sure that the file accessible from the webpage that is making the request. For security reasons, Ionicons does not allow scripts or events within the custom SVG element.
 
 import CustomURL from '@site/static/usage/custom-icons/url.md';
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -19,7 +19,7 @@ import BasicUsage from '@site/static/usage/basic-usage.md';
 
 ### With a URL
 
-To load a custom SVG from a url, pass the URL to the `icon` property. Make sure that the file accessible from the webpage that is making the request. For security reasons, Ionicons does not allow scripts or events within the custom SVG element.
+To load a custom SVG from a URL, pass the URL to the `icon` property. Make sure that the file is accessible from the webpage that is making the request. For security reasons, Ionicons does not allow scripts or events within the custom SVG element.
 
 import CustomURL from '@site/static/usage/custom-icons/url.md';
 

--- a/static/img/logo-stencil.svg
+++ b/static/img/logo-stencil.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><title>Logo Stencil</title><path d="M188.8 334.07h197.33L279.47 448H83.2zM512 199H106.61L0 313h405.39zM232.2 64h196.6L322.62 177.93H125.87z"/></svg>

--- a/static/usage/custom-icons/data.md
+++ b/static/usage/custom-icons/data.md
@@ -1,0 +1,109 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="angular" label="Angular">
+
+```html title="example.component.html"
+<ion-icon [icon]="customIcon"></ion-icon>
+```
+
+```typescript title="example.component.ts"
+import { Component } from '@angular/core';
+import svgData from '/path/to/external/file.svg';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  public customIcon = svgData;
+  constructor() {}
+}
+
+```
+</TabItem>
+
+<TabItem value="javascript" label="JavaScript">
+
+```html
+<ion-icon icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'>...</svg>"></ion-icon>
+```
+</TabItem>
+
+<TabItem value="react" label="React">
+
+## With Ionic Framework
+
+```tsx title="example.tsx"
+import { IonIcon } from '@ionic/react';
+import svgData from '/path/to/external/file.svg';
+
+const Example = () => {
+  return <IonIcon icon={svgData} />
+}
+
+export default Example;
+```
+
+## Without Ionic Framework
+
+```tsx title="example.tsx"
+import { defineCustomElement as defineIonIcon } from 'ionicons';
+import svgData from '/path/to/external/file.svg';
+
+defineIonIcon();
+
+const Example = () => {
+  return <ion-icon icon={svgData}></ion-icon>
+}
+
+export default Example;
+```
+</TabItem>
+
+<TabItem value="vue" label="Vue">
+
+## With Ionic Framework
+
+```html title="example.vue"
+<template>
+  <ion-icon :icon="svgData"></ion-icon>
+</template>
+
+<script>
+  import { defineComponent } from 'vue';
+  import { IonIcon } from '@ionic/vue';
+  import svgData from '/path/to/external/file.svg';
+
+  export default defineComponent({
+    components: { IonIcon },
+    setup() {
+      return { svgData };
+    }
+  });
+</script>
+```
+
+## Without Ionic Framework
+
+```html title="example.vue"
+<template>
+  <ion-icon :icon="svgData"></ion-icon>
+</template>
+
+<script>
+  import { defineComponent } from 'vue';
+  import { defineCustomElement as defineIonIcon } from 'ionicons';
+  import svgData from '/path/to/external/file.svg';
+
+  export default defineComponent({
+    setup() {
+      defineIonIcon();
+      return { svgData };
+    }
+  });
+</script>
+```
+</TabItem>
+</Tabs>

--- a/static/usage/custom-icons/data.md
+++ b/static/usage/custom-icons/data.md
@@ -5,19 +5,19 @@ import TabItem from '@theme/TabItem';
 <TabItem value="angular" label="Angular">
 
 ```html title="example.component.html"
-<ion-icon [icon]="customIcon"></ion-icon>
+<ion-icon [icon]="svgData"></ion-icon>
 ```
 
 ```typescript title="example.component.ts"
 import { Component } from '@angular/core';
-import svgData from '/path/to/external/file.svg';
+import customIcon from '/path/to/external/file.svg';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
 })
 export class ExampleComponent {
-  public customIcon = svgData;
+  public svgData = customIcon;
   constructor() {}
 }
 

--- a/static/usage/custom-icons/url.md
+++ b/static/usage/custom-icons/url.md
@@ -1,0 +1,86 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="angular" label="Angular">
+
+```html title="example.component.html"
+<ion-icon icon="/path/to/external/file.svg"></ion-icon>
+```
+</TabItem>
+
+<TabItem value="javascript" label="JavaScript">
+
+```html
+<ion-icon icon="/path/to/external/file.svg"></ion-icon>
+```
+</TabItem>
+
+<TabItem value="react" label="React">
+
+## With Ionic Framework
+
+```tsx title="example.tsx"
+import { IonIcon } from '@ionic/react';
+
+const Example = () => {
+  return <IonIcon icon="/path/to/external/file.svg" />
+}
+
+export default Example;
+```
+
+## Without Ionic Framework
+
+```tsx title="example.tsx"
+import { defineCustomElement as defineIonIcon } from 'ionicons';
+
+defineIonIcon();
+
+const Example = () => {
+  return <ion-icon icon="/path/to/external/file.svg"></ion-icon>
+}
+
+export default Example;
+```
+</TabItem>
+
+<TabItem value="vue" label="Vue">
+
+## With Ionic Framework
+
+```html title="example.vue"
+<template>
+  <ion-icon icon="/path/to/external/file.svg"></ion-icon>
+</template>
+
+<script>
+  import { defineComponent } from 'vue';
+  import { IonIcon } from '@ionic/vue';
+
+  export default defineComponent({
+    components: { IonIcon }
+  });
+</script>
+```
+
+## Without Ionic Framework
+
+```html title="example.vue"
+<template>
+  <ion-icon icon="/path/to/external/file.svg"></ion-icon>
+</template>
+
+<script>
+  import { defineComponent } from 'vue';
+  import { defineCustomElement as defineIonIcon } from 'ionicons';
+
+  export default defineComponent({
+    setup() {
+      defineIonIcon();
+    }
+  });
+</script>
+```
+</TabItem>
+</Tabs>


### PR DESCRIPTION
Adds docs on how to use custom icons by providing a URL or raw SVG data. Currently unable to show live demo due to an issue with ionicons.